### PR TITLE
fixtures for product, product version, and suite api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.pyc
 .DS_Store
 *.egg-info*
+build/
+dist/

--- a/README.rst
+++ b/README.rst
@@ -50,19 +50,9 @@ Running the tests for this project requires the following py.test flags:
     --test-mt-username
     --test-mt-apikey
 
-Troubleshooting:
-----------------
-if you get
-
-            try:
-                res = requests.get(url)
-                res.raise_for_status()
-                return res
-            except:
-    >           print res.text
+If you are running against a real moztrap instance (moztrap.mozilla.org or moztrap.allizom.org) you will also need 
+    --test-mt-protocol=https. 
+If you have the wrong protocol, it will often result in 
     E           UnboundLocalError: local variable 'res' referenced before assignment
 
-then fix the protocol at conftest.py line 56
-
-
-
+There are currently two sets of tests, one for the connector (test_connect.py) and one for the fixtures (the tests/ directory). The connector tests must be run against --test-mt-url=moztrap.allizom.org --test-mt-protocol=https. The fixture tests may be run against any moztrap server, including localhost with --test-mt-protocol=http.

--- a/conftest.py
+++ b/conftest.py
@@ -35,6 +35,11 @@ def pytest_addoption(parser):
                      metavar='str',
                      help="Ask your MozTrap admin to generate an API key "
                      "in the Core / ApiKeys table and provide it to you.")
+    group._addoption('--test-mt-protocol',
+                     action='store',
+                     dest='test_moztrap_protocol',
+                     default='http',
+                     help='http/https defaults to http')
 
 
 def pytest_sessionstart(session):
@@ -51,9 +56,10 @@ def pytest_runtest_setup(item):
     TestSetup.username = item.config.option.test_moztrap_username
     TestSetup.apikey = item.config.option.test_moztrap_apikey
     TestSetup.url = item.config.option.test_moztrap_url
+    TestSetup.protocol = item.config.option.test_moztrap_protocol
 
     TestSetup.connect = Connect(
-        "https",
+        TestSetup.protocol,
         TestSetup.url,
         TestSetup.username,
         TestSetup.apikey,
@@ -63,31 +69,28 @@ def pytest_runtest_setup(item):
 @pytest.fixture()
 def product_fixture(request, testmoztrap):
     from mtconnect.fixtures import ProductFixture
-    return ProductFixture.list(testmoztrap.connect, name="Macaron")[0]
 
-    # dt_string = datetime.utcnow().isoformat()
+    dt_string = datetime.utcnow().isoformat()
 
-    # fields = {
-    #     'name': 'TestProduct_fixture_%s' % dt_string,
-    #     'description': 'TestProduct_fixture_ %s' % dt_string,
-        # 'productversions': {
-        #     'version': 'test_create_product_%s' % dt_string,
-        #     'profile': '1',
-        # }
-    # }
-    # product_fixture = ProductFixture(testmoztrap.connect, fields)
+    fields = {
+        'name': 'TestProduct_fixture_%s' % dt_string,
+        'description': 'TestProduct_fixture_ %s' % dt_string,
+        'productversions': [{
+            'version': 'test_create_product_%s' % dt_string,
+        }]
+    }
+    product_fixture = ProductFixture(testmoztrap.connect, fields)
 
-    # def teardown():
-    #     product_fixture.delete()
+    def teardown():
+        product_fixture.delete()
 
-    # request.addfinalizer(teardown)
+    request.addfinalizer(teardown)
 
-    # return product_fixture
+    return product_fixture
 
 @pytest.fixture()
 def suite_fixture(request, testmoztrap, product_fixture):
     from mtconnect.fixtures import SuiteFixture
-    # return SuiteFixture.list(testmoztrap.connect, name="Macaron")[0]
 
     dt_string = datetime.utcnow().isoformat()
 

--- a/conftest.py
+++ b/conftest.py
@@ -4,6 +4,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 import pytest
+from datetime import datetime
 
 from mtconnect.connect import Connect
 
@@ -56,7 +57,54 @@ def pytest_runtest_setup(item):
         TestSetup.url,
         TestSetup.username,
         TestSetup.apikey,
+        DEBUG=True,
         )
+
+@pytest.fixture()
+def product_fixture(request, testmoztrap):
+    from mtconnect.fixtures import ProductFixture
+    return ProductFixture.list(testmoztrap.connect, name="Macaron")[0]
+
+    # dt_string = datetime.utcnow().isoformat()
+
+    # fields = {
+    #     'name': 'TestProduct_fixture_%s' % dt_string,
+    #     'description': 'TestProduct_fixture_ %s' % dt_string,
+        # 'productversions': {
+        #     'version': 'test_create_product_%s' % dt_string,
+        #     'profile': '1',
+        # }
+    # }
+    # product_fixture = ProductFixture(testmoztrap.connect, fields)
+
+    # def teardown():
+    #     product_fixture.delete()
+
+    # request.addfinalizer(teardown)
+
+    # return product_fixture
+
+@pytest.fixture()
+def suite_fixture(request, testmoztrap, product_fixture):
+    from mtconnect.fixtures import SuiteFixture
+    # return SuiteFixture.list(testmoztrap.connect, name="Macaron")[0]
+
+    dt_string = datetime.utcnow().isoformat()
+
+    fields = {
+        'name': 'TestSuite_fixture_%s' % dt_string,
+        'status': 'active',
+        'product': product_fixture.resource_uri,
+        'description': 'TestSuite_fixture %s' % dt_string,
+    }
+    suite_fixture = SuiteFixture(testmoztrap.connect, fields)
+
+    def teardown():
+        suite_fixture.delete()
+
+    request.addfinalizer(teardown)
+
+    return suite_fixture
 
 
 class TestSetup:

--- a/mtconnect/connect.py
+++ b/mtconnect/connect.py
@@ -1,3 +1,4 @@
+import sys
 import requests
 from urllib import urlencode
 from json import loads, dumps
@@ -53,6 +54,9 @@ class Connect:
 
 
     def do_get(self, resource, id=None, params={}):
+        if self.DEBUG:
+            sys.stdout.write("GET ")
+
         url = self.get_url(self.get_uri(resource, id), params)
 
         try:
@@ -64,9 +68,13 @@ class Connect:
 
 
     def do_patch(self, resource, data_obj, params={}):
+        if self.DEBUG:
+            sys.stdout.write("PATCH ")
+
         url = self.get_url(self.get_uri(resource), params)
 
         if self.DEBUG:
+            sys.stdout.write("data = ")
             print(dumps(data_obj, sort_keys=True, indent=4))
 
         try:
@@ -82,10 +90,35 @@ class Connect:
             return res
 
 
+    def do_put(self, resource, id, params={}):
+        if self.DEBUG:
+            sys.stdout.write("PUT ")
+
+        url = self.get_url(self.get_uri(resource, id))
+
+        if self.DEBUG:
+            sys.stdout.write("params = ")
+            print(dumps(params, sort_keys=True, indent=4))
+
+        try:
+            res = requests.put(
+                url,
+                data=dumps(params),
+                headers = {"content-type": "application/json"},
+                )
+            res.raise_for_status()
+            return res
+        except:
+            print res.text
+
     def do_post(self, resource, data_obj, params={}):
+        if self.DEBUG:
+            sys.stdout.write("POST ")
+
         url = self.get_url(self.get_uri(resource), params)
 
         if self.DEBUG:
+            sys.stdout.write("data = ")
             print(dumps(data_obj, sort_keys=True, indent=4))
 
         try:
@@ -99,6 +132,18 @@ class Connect:
         except:
             print res.text
 
+    def do_delete(self, resource, id):
+        if self.DEBUG:
+            sys.stdout.write("DELETE ")
+
+        url = self.get_url(self.get_uri(resource, id))
+
+        try:
+            res = requests.delete(url)
+            res.raise_for_status()
+            return res
+        except:
+            print res
 
     #######################################
     # connector APIs for creating a new run

--- a/mtconnect/connect.py
+++ b/mtconnect/connect.py
@@ -132,11 +132,11 @@ class Connect:
         except:
             print res.text
 
-    def do_delete(self, resource, id):
+    def do_delete(self, resource, id, params=None):
         if self.DEBUG:
             sys.stdout.write("DELETE ")
 
-        url = self.get_url(self.get_uri(resource, id))
+        url = self.get_url(self.get_uri(resource, id), params=params)
 
         try:
             res = requests.delete(url)

--- a/mtconnect/fixtures.py
+++ b/mtconnect/fixtures.py
@@ -1,4 +1,5 @@
 from json import loads
+from datetime import datetime
 import requests
 
 class _Fixture(object):
@@ -34,6 +35,10 @@ class _Fixture(object):
             self.id = r.headers['location'].split('/')[-2]
             self.get()
 
+    def __repr__(self):
+        '''Instance method. String representation of fixture.'''
+        return "%s with attributes %s" % (self.__class__.__name__, str(self.__dict__))
+
     def get(self):
         '''Instance method. Refresh the object with data from the server.'''
         r = self.connect.do_get(self._uri, self.id)
@@ -51,9 +56,12 @@ class _Fixture(object):
         self.connect.do_put(self._uri, self.id, fields)
         self.__dict__.update(fields)
 
-    def delete(self):
-        '''Instance method. Use the API to delete the object.'''
-        self.connect.do_delete(self._uri, self.id)
+    def delete(self, permanent=False):
+        '''Instance method. Use the API to delete the object.
+        ::Args::
+        permanent - True/False, defaults to False
+        '''
+        self.connect.do_delete(self._uri, self.id, params={"permanent": permanent})
 
     @classmethod
     def list(cls, connect, **filters):
@@ -87,3 +95,10 @@ class SuiteFixture(_Fixture):
     _edit_args = ['description', 'status', 'name', 'product']
     _create_args = _edit_args
     _filter_args = ['name', 'product']
+
+
+class ProductVersionFixture(_Fixture):
+    _uri = 'productversion'
+    _edit_args = ['version', 'codename']
+    _create_args = _edit_args + ['product']
+    _filter_args = ['version', 'product']

--- a/mtconnect/fixtures.py
+++ b/mtconnect/fixtures.py
@@ -1,0 +1,89 @@
+from json import loads
+import requests
+
+class _Fixture(object):
+
+    _edit_args = []
+    _create_args = [_edit_args, ]
+    _filter_args = []
+
+    @classmethod
+    def _verify_args(cls, actual_args, allowed_args, method):
+        for arg in actual_args.keys():
+            if not arg in allowed_args:
+                raise Exception("%s not an allowed arguement for %s.%s." % (
+                    arg, cls.__name__, method))
+
+    def __init__(self, connect, fields={}, _data=None):
+        '''Instance constructor. Use the API to create a object.
+
+        ::Args::
+        connect - an mtconnect.connect.Connect object
+        fields - a dictionary of field names and values
+
+        Also used internally to create Fixtures out of data from list methods.
+        '''
+        cls = self.__class__
+        self.connect = connect
+        if _data:
+            # create object for existing record
+            self.__dict__.update(_data)
+        else:
+            self._verify_args(fields, self._create_args, '__init__')
+            r = connect.do_post(self._uri, fields)
+            self.id = r.headers['location'].split('/')[-2]
+            self.get()
+
+    def get(self):
+        '''Instance method. Refresh the object with data from the server.'''
+        r = self.connect.do_get(self._uri, self.id)
+        data = loads(r.text)
+        self.__dict__.update(data)
+
+    def edit(self, fields):
+        '''Instance method. Use the API to edit the object.
+
+        ::Args::
+        fields - dictionary of field names and values
+
+        '''
+        self._verify_args(fields, self._edit_args, 'edit')
+        self.connect.do_put(self._uri, self.id, fields)
+        self.__dict__.update(fields)
+
+    def delete(self):
+        '''Instance method. Use the API to delete the object.'''
+        self.connect.do_delete(self._uri, self.id)
+
+    @classmethod
+    def list(cls, connect, **filters):
+        '''Class method. Query the API for existing object.
+
+        ::Args::
+        connect - an mtconnect.connect.Connect object.
+
+        ::Keyword Args (filters)::
+
+        ::Returns::
+        A potentially empty list of _Fixture objects will be returned.
+        '''
+        cls._verify_args(filters, cls._filter_args, 'find')
+
+        r = connect.do_get(cls._uri, params=filters)
+        objects = loads(r.text)["objects"]
+
+        return [cls(connect, _data=obj) for obj in objects]
+
+
+class ProductFixture(_Fixture):
+    _uri = 'product'
+    _edit_args = ['description']
+    _create_args = _edit_args + ['name', 'productversions']
+    _filter_args = ['name']
+
+
+class SuiteFixture(_Fixture):
+    _uri = 'suite'
+    _edit_args = ['description', 'status', 'name', 'product']
+    _create_args = _edit_args
+    _filter_args = ['name', 'product']

--- a/test_connect.py
+++ b/test_connect.py
@@ -7,14 +7,7 @@ from mtconnect.connect import InvalidFilterParamsException
 from mtconnect.connect import ProductVersionDoesNotExistException
 
 
-
 class TestConnect:
-
-    def test_get_runs_filter_by_product_name(self):
-        runs = self.connect.get_runs(product="Macaron")
-        print "runs:\n%s" % runs
-        run_names = [r['name'] for r in runs]
-        assert "Vanilla mousse" in run_names
 
     # constructor
     def test_connect_limits(self, testmoztrap):
@@ -66,16 +59,16 @@ class TestConnect:
         assert found, "product version 1 not found in %s" % vers
 
 
-    def test_get_productversions_by_product_name_and_version_name(self,
+    def test_get_productversions_by_product_name_and_version_name(self, 
             testmoztrap):
-        vers = testmoztrap.connect.get_productversions(product="Macaron",
+        vers = testmoztrap.connect.get_productversions(product="Macaron", 
             version="1")
         print "versions:\n%s" % vers
         assert len(vers) == 1
         assert vers[0]['id'] == "33", vers
 
 
-    def test_get_productversions_by_version_name_only_throws_exception(self,
+    def test_get_productversions_by_version_name_only_throws_exception(self, 
             testmoztrap):
         with pytest.raises(InvalidFilterParamsException) as e:
             vers = testmoztrap.connect.get_productversions(version="1")
@@ -113,7 +106,7 @@ class TestConnect:
         "and version are required." in e.exconly()
 
 
-    def test_get_runs_filter_by_just_product_name_raises_exception(self,
+    def test_get_runs_filter_by_just_product_name_raises_exception(self, 
             testmoztrap):
         with pytest.raises(InvalidFilterParamsException) as e:
            runs = testmoztrap.connect.get_runs(product="Macaron")
@@ -122,7 +115,7 @@ class TestConnect:
         "version are required." in e.exconly()
 
 
-    def test_get_runs_filter_by_just_version_name_raises_exception(self,
+    def test_get_runs_filter_by_just_version_name_raises_exception(self, 
             testmoztrap):
         with pytest.raises(InvalidFilterParamsException) as e:
             runs = testmoztrap.connect.get_runs(version="0.1a")
@@ -130,7 +123,7 @@ class TestConnect:
         assert "Either run_id or productversion_id or product and "
         "version are required." in e.exconly()
 
-
+    @pytest.mark.xfail(reason="productversion_id -> productversion_name")
     def test_get_runs_filter_by_productversion_id(self, testmoztrap):
         runs = testmoztrap.connect.get_runs(productversion_id=31)
         print "runs:\n%s" % runs
@@ -154,12 +147,12 @@ class TestConnect:
         assert runs[0]['id'] == "47"
 
 
-    def test_get_runs_no_product_version_match_throws_exception(self,
+    def test_get_runs_no_product_version_match_throws_exception(self, 
             testmoztrap):
         with pytest.raises(ProductVersionDoesNotExistException) as e:
             runs = testmoztrap.connect.get_runs(
-                product="nonexistant product",
-                version="nonexistant version",
+                product="nonexistant product", 
+                version="nonexistant version", 
                 name="nonexistant run")
         assert "No productversion found matching product=nonexistant product "
         "and version=nonexistant version." in str(e.exconly())

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,0 +1,8 @@
+from datetime import datetime
+
+class Base(object):
+    """Base class for test classes."""
+
+    @property
+    def timestamp(self):
+        return datetime.utcnow().isoformat()

--- a/tests/test_product.py
+++ b/tests/test_product.py
@@ -1,0 +1,54 @@
+#!python
+
+import pytest
+
+from mtconnect.fixtures import ProductFixture
+from base import Base
+
+
+class TestProduct(Base):
+
+    def test_create_delete_product(self, testmoztrap):
+        dt_string = self.timestamp
+
+        fields = {
+            'name': 'test_create_product_%s' % dt_string,
+            'description': 'test_create_product %s' % dt_string,
+            'productversions': [{
+                'version': 'test_create_product_%s' % dt_string,
+            }]
+        }
+        product = ProductFixture(testmoztrap.connect, fields)
+        prods = ProductFixture.list(testmoztrap.connect, name=product.name)
+        assert len(prods) == 1
+        product.delete()
+        prods = ProductFixture.list(testmoztrap.connect, name=product.name)
+        assert len(prods) == 0
+
+    def test_edit_get_product(self, testmoztrap, product_fixture):
+        dt_string = self.timestamp
+        fields = { 'description': 'test_edit_product %s' % dt_string}
+        product_fixture.edit(fields)
+        product_fixture.get()
+        assert product_fixture.description == fields['description']
+
+    def test_list_products(self, testmoztrap, product_fixture):
+        prods = ProductFixture.list(testmoztrap.connect)
+        found = False
+        for prod in prods:
+            if prod.name == product_fixture.name:
+                found = True
+                assert prod.productversions == product_fixture.productversions
+                assert prod.description == product_fixture.description
+        assert found, "product %s not found" % product_fixture.name
+
+
+    def test_list_product_by_name(self, testmoztrap, product_fixture):
+        prod = ProductFixture.list(testmoztrap.connect, name=product_fixture.name)[0]
+        assert prod.id == product_fixture.id
+        assert prod.description == product_fixture.description
+        assert prod.productversions == product_fixture.productversions
+
+    def test_product_not_found_by_name(self, testmoztrap):
+        prod_list = ProductFixture.list(testmoztrap.connect, name="this product does not exist")
+        assert prod_list == []

--- a/tests/test_product.py
+++ b/tests/test_product.py
@@ -3,6 +3,7 @@
 import pytest
 
 from mtconnect.fixtures import ProductFixture
+from mtconnect.connect import Connect
 from base import Base
 
 
@@ -11,13 +12,7 @@ class TestProduct(Base):
     def test_create_delete_product(self, testmoztrap):
         dt_string = self.timestamp
 
-        fields = {
-            'name': 'test_create_product_%s' % dt_string,
-            'description': 'test_create_product %s' % dt_string,
-            'productversions': [{
-                'version': 'test_create_product_%s' % dt_string,
-            }]
-        }
+        fields = ProductFixture.fixture_data()
         product = ProductFixture(testmoztrap.connect, fields)
         prods = ProductFixture.list(testmoztrap.connect, name=product.name)
         assert len(prods) == 1
@@ -52,3 +47,20 @@ class TestProduct(Base):
     def test_product_not_found_by_name(self, testmoztrap):
         prod_list = ProductFixture.list(testmoztrap.connect, name="this product does not exist")
         assert prod_list == []
+
+    def test_list_pagination(self, testmoztrap):
+        # create 5 products 
+        for i in range(5):
+            ProductFixture(testmoztrap.connect, ProductFixture.fixture_data())
+
+        # use connect with limit=1
+        connect = Connect(
+            testmoztrap.protocol,
+            testmoztrap.url,
+            testmoztrap.username,
+            testmoztrap.apikey,
+            limit=1,
+            )
+        # verify results has five products
+        products = ProductFixture.list(connect)
+        assert len(products) >= 5

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -1,12 +1,12 @@
 #!python
 
 import pytest
-from datetime import datetime
 
 from mtconnect.fixtures import SuiteFixture
+from base import Base
 
 
-class TestSuite:
+class TestSuite(Base):
 
     def test_list_suites(self, testmoztrap, suite_fixture, product_fixture):
         suites = SuiteFixture.list(testmoztrap.connect)
@@ -21,7 +21,7 @@ class TestSuite:
         assert found, "suite %s not found" % suite_fixture.name
 
     def test_create_delete_suite(self, testmoztrap, product_fixture):
-        dt_string = datetime.utcnow().isoformat()
+        dt_string = self.timestamp
 
         fields = {
             'name': 'test_create_delete_suite_%s' % dt_string,
@@ -43,7 +43,7 @@ class TestSuite:
         assert len(suites) == 0
 
     def test_edit_get_suite(self, testmoztrap, suite_fixture):
-        dt_string = datetime.utcnow().isoformat()
+        dt_string = self.timestamp
         fields = { 
             'description': 'test_edit_get_suite %s' % dt_string,
             'status': 'draft',

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -1,0 +1,79 @@
+#!python
+
+import pytest
+from datetime import datetime
+
+from mtconnect.fixtures import SuiteFixture
+
+
+class TestSuite:
+
+    def test_list_suites(self, testmoztrap, suite_fixture, product_fixture):
+        suites = SuiteFixture.list(testmoztrap.connect)
+        found = False
+        for suite in suites:
+            print suite.__dict__
+            if suite.name == suite_fixture.name:
+                found = True
+                # assert suite.product_id == product_fixture.id
+                assert suite.description == suite_fixture.description
+                assert suite.status == suite_fixture.status
+        assert found, "suite %s not found" % suite_fixture.name
+
+    def test_create_delete_suite(self, testmoztrap, product_fixture):
+        dt_string = datetime.utcnow().isoformat()
+
+        fields = {
+            'name': 'test_create_delete_suite_%s' % dt_string,
+            'description': 'test_create_delete_suite %s' % dt_string,
+            'product': product_fixture.resource_uri,
+            'status': 'active',
+        }
+        suite = SuiteFixture(testmoztrap.connect, fields)
+        assert suite.name == fields['name']
+        assert suite.description == fields['description']
+        assert suite.product == product_fixture.resource_uri
+        assert suite.status == fields['status']
+
+        suites = SuiteFixture.list(testmoztrap.connect, name=suite.name)
+        assert len(suites) == 1
+
+        suite.delete()
+        suites = SuiteFixture.list(testmoztrap.connect, name=suite.name)
+        assert len(suites) == 0
+
+    def test_edit_get_suite(self, testmoztrap, suite_fixture):
+        dt_string = datetime.utcnow().isoformat()
+        fields = { 
+            'description': 'test_edit_get_suite %s' % dt_string,
+            'status': 'draft',
+            }
+        suite_fixture.edit(fields)
+        suite_fixture.get()
+        assert suite_fixture.description == fields['description']
+        assert suite_fixture.status == fields['status']
+
+    def test_list_suites_by_name(self, testmoztrap, suite_fixture):
+        suite_list = SuiteFixture.list(testmoztrap.connect, name=suite_fixture.name)
+        assert len(suite_list) == 1
+        suite = suite_list[0]
+        assert suite.id == suite_fixture.id
+        assert suite.description == suite_fixture.description
+        assert suite.status == suite_fixture.status
+
+    def test_suite_not_found_by_name(self, testmoztrap):
+        suite_list = SuiteFixture.list(testmoztrap.connect, name="this product does not exist")
+        assert suite_list == []
+
+    def test_list_suites_by_product(self, testmoztrap, product_fixture, suite_fixture):
+        suite_list = SuiteFixture.list(testmoztrap.connect, product=product_fixture.id)
+        assert len(suite_list) == 1
+        suite = suite_list[0]
+        assert suite.id == suite_fixture.id
+        assert suite.description == suite_fixture.description
+        assert suite.status == suite_fixture.status
+        assert suite.product == product_fixture.resource_uri
+
+    def test_suite_not_found_by_product(self, testmoztrap):
+        suite_list = SuiteFixture.list(testmoztrap.connect, product=9999999)
+        assert suite_list == []

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -23,12 +23,7 @@ class TestSuite(Base):
     def test_create_delete_suite(self, testmoztrap, product_fixture):
         dt_string = self.timestamp
 
-        fields = {
-            'name': 'test_create_delete_suite_%s' % dt_string,
-            'description': 'test_create_delete_suite %s' % dt_string,
-            'product': product_fixture.resource_uri,
-            'status': 'active',
-        }
+        fields = SuiteFixture.fixture_data(product_fixture)
         suite = SuiteFixture(testmoztrap.connect, fields)
         assert suite.name == fields['name']
         assert suite.description == fields['description']

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,92 @@
+#!python
+
+import pytest
+
+from mtconnect.fixtures import ProductVersionFixture
+from base import Base
+
+
+class TestVersion(Base):
+
+    def test_create_delete_productversion(self, testmoztrap, product_fixture):
+        dt_string = self.timestamp
+
+        # before create
+        vers = ProductVersionFixture.list(testmoztrap.connect, 
+            product=product_fixture.id)
+        assert len(vers) == 1
+
+        # do create
+        fields = {
+            'version': 'test_create_product_version_%s' % dt_string,
+            'codename': 'test_create_product_version_%s' % dt_string,
+            'product': product_fixture.resource_uri,
+            }
+
+        version = ProductVersionFixture(testmoztrap.connect, fields)
+
+        vers = ProductVersionFixture.list(testmoztrap.connect, 
+            product=product_fixture.id)
+        assert len(vers) == 2
+
+        # do delete
+        version.delete()
+
+        vers = ProductVersionFixture.list(testmoztrap.connect,
+            product=product_fixture.id)
+        assert len(vers) == 1
+
+    def test_edit_get_productversion(self, testmoztrap, product_fixture):
+        dt_string = self.timestamp
+
+        version = ProductVersionFixture.list(testmoztrap.connect,
+            product=product_fixture.id)[0]
+
+        fields = { 
+            'version': 'test_edit_productversion %s' % dt_string,
+            'codename': 'test_edit_productversion %s' % dt_string,
+            }
+        version.edit(fields)
+        version.get()
+        assert version.version == fields['version']
+        assert version.codename == fields['codename']
+
+    def test_list_productversions_by_product_name_only(self, testmoztrap, product_fixture):
+        vers = ProductVersionFixture.list(testmoztrap.connect,
+            product=product_fixture.id)
+        version = product_fixture.productversions[0]['version']
+        found = False
+        print "versions:\n%s" % vers
+        for ver in vers:
+            if ver.version == version:
+                found = True
+        assert found, "product version %s not found in %s" % (version, vers)
+
+    def test_list_productversions_by_version_name(self, 
+            testmoztrap, product_fixture):
+        version = product_fixture.productversions[0]['version']
+        vers = ProductVersionFixture.list(testmoztrap.connect,
+            version=version)
+        found = False
+        print "versions:\n%s" % vers
+        for ver in vers:
+            if ver.version == version:
+                found = True
+        assert found, "product version %s not found in %s" % (version, vers)
+
+    def test_list_productversions_by_product_name_and_version_name(self, 
+            testmoztrap, product_fixture):
+        version = product_fixture.productversions[0]['version']
+        vers = ProductVersionFixture.list(testmoztrap.connect,
+            product=product_fixture.id, 
+            version=version)
+        print "versions:\n%s" % vers
+        assert len(vers) == 1
+        ver = vers[0]
+        assert ver.id == product_fixture.productversions[0]['id'], vers
+
+    def test_productversion_not_found_by_name(self, testmoztrap):
+        versions = ProductVersionFixture.list(testmoztrap.connect, 
+            version="this productversion does not exist")
+        assert versions == []
+

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -11,20 +11,16 @@ class TestVersion(Base):
     def test_create_delete_productversion(self, testmoztrap, product_fixture):
         dt_string = self.timestamp
 
-        # before create
+        # list should have 1
         vers = ProductVersionFixture.list(testmoztrap.connect, 
             product=product_fixture.id)
         assert len(vers) == 1
 
         # do create
-        fields = {
-            'version': 'test_create_product_version_%s' % dt_string,
-            'codename': 'test_create_product_version_%s' % dt_string,
-            'product': product_fixture.resource_uri,
-            }
-
+        fields = ProductVersionFixture.fixture_data(product_fixture)
         version = ProductVersionFixture(testmoztrap.connect, fields)
 
+        # list should have 2
         vers = ProductVersionFixture.list(testmoztrap.connect, 
             product=product_fixture.id)
         assert len(vers) == 2
@@ -32,6 +28,7 @@ class TestVersion(Base):
         # do delete
         version.delete()
 
+        # list should have one
         vers = ProductVersionFixture.list(testmoztrap.connect,
             product=product_fixture.id)
         assert len(vers) == 1


### PR DESCRIPTION
test_connect.py needs to be run against moztrap.allizom.org with an https connection
tests/test_suite.py can be run against prod / stage or a local instance.
tests/test_product.py and tests/test_version.py need to be run against a local instance of moztrap with mozilla/moztrap#12

also fixes pagination and provides a command line argument for protocol
